### PR TITLE
✨ Docker Desktopのインストールスクリプト追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ## OS
 
-- debian
 - ubuntu
 - macOS（予定）
 

--- a/install.sh
+++ b/install.sh
@@ -301,6 +301,40 @@ check_environment() {
       SUMMARY_ENV+=("DOTFILES_HOST=true → VSCode インストール失敗")
     fi
     rm -f "$tmpdeb_vscode"
+
+    # Docker Desktop
+    # 1. Docker apt リポジトリのセットアップ
+    sudo apt install -y ca-certificates curl
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+    sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+    sudo apt update
+
+    # 2. KVM 仮想化サポート（Docker Desktop の動作に必須）
+    sudo modprobe kvm
+    sudo usermod -aG kvm "$USER"
+    SUMMARY_ENV+=("DOTFILES_HOST=true → KVM: $USER を kvm グループに追加 (再ログイン後に有効)")
+
+    # 3. Docker Desktop .deb のダウンロード＆インストール
+    tmpdeb_docker="/tmp/docker-desktop-amd64.deb"
+    if curl -fsSL -o "$tmpdeb_docker" "https://desktop.docker.com/linux/main/amd64/docker-desktop-amd64.deb" \
+      && sudo apt install -y "$tmpdeb_docker"; then
+      # 4. ログイン時に自動起動
+      systemctl --user enable docker-desktop 2>/dev/null || true
+      SUMMARY_ENV+=("DOTFILES_HOST=true → Docker Desktop インストール済み (再ログイン後に利用可能)")
+    else
+      echo "[ERROR] Docker Desktopのインストールに失敗しました" >&2
+      SUMMARY_ENV+=("DOTFILES_HOST=true → Docker Desktop インストール失敗")
+    fi
+    rm -f "$tmpdeb_docker"
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -324,8 +324,9 @@ EOF
     SUMMARY_ENV+=("DOTFILES_HOST=true → KVM: $USER を kvm グループに追加 (再ログイン後に有効)")
 
     # 3. Docker Desktop .deb のダウンロード＆インストール
-    tmpdeb_docker="/tmp/docker-desktop-amd64.deb"
-    if curl -fsSL -o "$tmpdeb_docker" "https://desktop.docker.com/linux/main/amd64/docker-desktop-amd64.deb" \
+    arch=$(dpkg --print-architecture)
+    tmpdeb_docker="/tmp/docker-desktop-${arch}.deb"
+    if curl -fsSL -o "$tmpdeb_docker" "https://desktop.docker.com/linux/main/${arch}/docker-desktop-${arch}.deb" \
       && sudo apt install -y "$tmpdeb_docker"; then
       # 4. ログイン時に自動起動
       systemctl --user enable docker-desktop 2>/dev/null || true

--- a/zsh/abbreviations
+++ b/zsh/abbreviations
@@ -1,3 +1,4 @@
+abbr "cat"="batcat"
 abbr "gr"="git reset --soft HEAD^"
 abbr "ls"="eza --icons"
 abbr "lsa"="eza -la --icons"

--- a/zsh/common.zsh
+++ b/zsh/common.zsh
@@ -62,7 +62,7 @@ _ZSH_PLUGIN_DIR="${HOME}/.local/share/zsh/plugins"
 
 # zsh-abbr: abbreviation ファイルを dotfiles で管理
 ABBR_USER_ABBREVIATIONS_FILE="${DOTFILES_DIR}/zsh/abbreviations"
-ABBR_QUIET=1
+ABBR_QUIETER=1
 [ -f "${_ZSH_PLUGIN_DIR}/zsh-abbr/zsh-abbr.zsh" ] \
     && source "${_ZSH_PLUGIN_DIR}/zsh-abbr/zsh-abbr.zsh"
 

--- a/zsh/common.zsh
+++ b/zsh/common.zsh
@@ -62,6 +62,7 @@ _ZSH_PLUGIN_DIR="${HOME}/.local/share/zsh/plugins"
 
 # zsh-abbr: abbreviation ファイルを dotfiles で管理
 ABBR_USER_ABBREVIATIONS_FILE="${DOTFILES_DIR}/zsh/abbreviations"
+ABBR_QUIET=1
 [ -f "${_ZSH_PLUGIN_DIR}/zsh-abbr/zsh-abbr.zsh" ] \
     && source "${_ZSH_PLUGIN_DIR}/zsh-abbr/zsh-abbr.zsh"
 


### PR DESCRIPTION
## Summary
- `install.sh`: Docker apt リポジトリのセットアップ、KVM仮想化サポート設定、Docker Desktop .deb のインストール処理を追加
- `zsh/abbreviations`: `cat` → `batcat` のエイリアスを追加

## Test plan
- [ ] `install.sh` を実行し Docker Desktop が正常にインストールされることを確認
- [ ] `kvm` グループへの追加が行われることを確認
- [ ] 再ログイン後に `docker` コマンドが利用可能なことを確認
- [ ] `cat` コマンドが `batcat` に置き換わることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)